### PR TITLE
notewolfy: Improvement regarding escape sequences and command behavior

### DIFF
--- a/.github/workflows/ci_go.yaml
+++ b/.github/workflows/ci_go.yaml
@@ -1,0 +1,22 @@
+name: Go CI
+
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.24', '1.23']
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Unit Tests with Coverage
+      run: go test -v ./... --timeout 5m -cover -tags unit_test
+    - name: Integration Tests with Coverage
+      run: go test -v ./... --timeout 15m -cover -tags integration_test
+    - name: E2E Tests with Coverage
+      run: go test -v ./... --timeout 60m -cover -tags e2e_test

--- a/.github/workflows/ci_go.yaml
+++ b/.github/workflows/ci_go.yaml
@@ -13,11 +13,11 @@ jobs:
         with:
           go-version: '1.24'
 
-      - name: Unit Tests with Coverage
+      - name: Unit Tests
         run: go test -v ./... --timeout 5m -tags unit_test
 
-      - name: Integration Tests with Coverage
+      - name: Integration Tests
         run: go test -v ./... --timeout 15m -tags integration_test
 
-      - name: E2E Tests with Coverage
+      - name: E2E Tests
         run: go test -v ./... --timeout 60m -tags e2e_test

--- a/.github/workflows/ci_go.yaml
+++ b/.github/workflows/ci_go.yaml
@@ -5,18 +5,19 @@ on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.24', '1.23']
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v4
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: Unit Tests with Coverage
-      run: go test -v ./... --timeout 5m -cover -tags unit_test
-    - name: Integration Tests with Coverage
-      run: go test -v ./... --timeout 15m -cover -tags integration_test
-    - name: E2E Tests with Coverage
-      run: go test -v ./... --timeout 60m -cover -tags e2e_test
+      - uses: actions/checkout@v3
+
+      - name: Set up Go 1.24
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24'
+
+      - name: Unit Tests with Coverage
+        run: go test -v ./... --timeout 5m -tags unit_test
+
+      - name: Integration Tests with Coverage
+        run: go test -v ./... --timeout 15m -tags integration_test
+
+      - name: E2E Tests with Coverage
+        run: go test -v ./... --timeout 60m -tags e2e_test

--- a/CHANGELOG/v0.2.0.md
+++ b/CHANGELOG/v0.2.0.md
@@ -1,0 +1,10 @@
+# v0.2.0
+## Features
+## Enhancements
+- Enhanced feedback for invalid user inputs, especially when not matching expected patterns (e.g. regular expressions)
+- The 'help' command displays a list of available options, making it easier for users to discover supported commands and usage
+## Bug Fixes
+- The 'help' output now includes the 'edit' command
+- Pressing arrow keys and other special keys does not quit notewolfy anymore
+- When using the 'edit' command, vim is opened and not vi
+## Notes

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright [2024] [RaphSku]
+   Copyright 2025 RaphSku
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ A bulk delete is currently not supported but if you want to delete the whole wor
 
 If you need help with a command, try to use
 ```bash
-help create workspace
+>>> help create workspace
 ```
 
 If you want to see the version of notewolfy that you are using, just use the following command

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # notewolfy
 ## Description
-notewolfy simplifies note-taking and organization into a straightforward tree-like structure. Currently, notewolfy supports note-taking through Markdown files via Vim. If you're unfamiliar with Vim, I recommend learning it before using notewolfy. Take notes of something noteworthy.
+notewolfy streamlines note-taking and organization using a simple, tree-like structure. It currently works with Markdown files through Vim. If you're not familiar with Vim, I recommend learning it first to get the most out of notewolfy. Use it to capture anything you find noteworthy.
 
 ## How to get it
 You can get notewolfy with the following command:
@@ -85,5 +85,7 @@ or inside of notewolfy
 ```
 there is also the version command available.
 
-## Supported OS
+## Supported OS & Terminal
 Only UNIX operating systems are supported. Sorry, no Windows for the time being.
+notewolfy has been tested on the following terminals:
+- bash

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -6,17 +6,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const VERSION = "v0.1.0"
+const VERSION = "v0.2.0"
 
-func NewVersionCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "version",
-		Short: "Print the version of notewolfy.",
-		Long:  `This will show you the version of notewolfy in the format: v{MAJOR}.{MINOR}.{PATCH}`,
-		Run:   versionCommandFunc,
-	}
+type VersionCmd struct{}
+
+func NewVersionCmd() *VersionCmd {
+	return &VersionCmd{}
 }
 
-func versionCommandFunc(cmd *cobra.Command, args []string) {
+func (vc *VersionCmd) GetVersionCmd() *cobra.Command {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Prints the version number of notewolfy.",
+		Long:  `This will show you the version of notewolfy in the format: v{MAJOR}.{MINOR}.{PATCH}.`,
+		Run:   vc.runVersionCmd,
+	}
+
+	return versionCmd
+}
+
+func (vc *VersionCmd) runVersionCmd(cmd *cobra.Command, args []string) {
 	fmt.Println(VERSION)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RaphSku/notewolfy
 
-go 1.22.5
+go 1.24.2
 
 require (
 	github.com/google/uuid v1.6.0
@@ -18,7 +18,7 @@ require (
 )
 
 require (
-	github.com/RaphSku/cyclecmd v0.1.0
+	github.com/RaphSku/cyclecmd v0.2.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/multierr v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/RaphSku/cyclecmd v0.1.0 h1:MpYQtDMAJHId7D+q9uAo+3bq0z+8nKsfjFdw7gk8tJg=
-github.com/RaphSku/cyclecmd v0.1.0/go.mod h1:UN/EsbA3Am/uBxGO9AQzhxuOI7OELTK7bBqy5GML2iE=
+github.com/RaphSku/cyclecmd v0.2.0 h1:7LXpDCIe2VLJ2whobqTMgw4WkjRhvjeZC5iFol6A3So=
+github.com/RaphSku/cyclecmd v0.2.0/go.mod h1:P1jeG+xAKjA11/G45xw4w4Le768yHtP6BPBhCxQJ4jc=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/commands/command_test.go
+++ b/internal/commands/command_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/RaphSku/notewolfy/internal/commands"
@@ -1060,7 +1061,21 @@ func TestMatchStatementToListWorkspaces(t *testing.T) {
 				assert.NoError(t, err)
 				workspaceNameA := tc.workspacePaths[0][2:]
 				workspaceNameB := tc.workspacePaths[1][2:]
-				expOutput := fmt.Sprintf("\r\nWorkspace Name                                                                                              Workspace Path                                                                                          \r\n-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n\rtestA                                                                                                       %[1]s/%[2]s\n\rtestB                                                                                                       %[1]s/%[3]s\n", basePath, workspaceNameA, workspaceNameB)
+				maximumLength := 2 * len("Workspace Name")
+				if len(workspaceNameA) > maximumLength {
+					maximumLength = len(workspaceNameA)
+				}
+				if len(workspaceNameB) > maximumLength {
+					maximumLength = len(workspaceNameB)
+				}
+				if len(workspacePathA) > maximumLength {
+					maximumLength = len(workspacePathA)
+				}
+				if len(workspacePathB) > maximumLength {
+					maximumLength = len(workspacePathB)
+				}
+				totalWidth := 2*(maximumLength) + 1
+				expOutput := fmt.Sprintf("\r\nWorkspace Name                                                                                              Workspace Path                                                                                          \r\n%[4]s\n\rtestA                                                                                                       %[1]s/%[2]s\n\rtestB                                                                                                       %[1]s/%[3]s\n", basePath, workspaceNameA, workspaceNameB, strings.Repeat("-", totalWidth))
 				assert.Equal(t, expOutput, actOutput)
 
 				return

--- a/internal/commands/command_test.go
+++ b/internal/commands/command_test.go
@@ -900,7 +900,7 @@ func TestMatchStatementToVersion(t *testing.T) {
 			})
 			assert.NoError(t, err)
 			if tc.want {
-				expContentString := "\n\rnotewolfy version v0.1.0 at your disposal!"
+				expContentString := "\n\rnotewolfy version v0.2.0 at your disposal!"
 				assert.Equal(t, expContentString, actOutput)
 
 				return
@@ -1060,7 +1060,7 @@ func TestMatchStatementToListWorkspaces(t *testing.T) {
 				assert.NoError(t, err)
 				workspaceNameA := tc.workspacePaths[0][2:]
 				workspaceNameB := tc.workspacePaths[1][2:]
-				expOutput := fmt.Sprintf("\r\nWorkspace Name                                                                                            Workspace Path                                                                                            \r\n---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n\rtestA                                                                                                     %[1]s/%[2]s\n\rtestB                                                                                                     %[1]s/%[3]s\n", basePath, workspaceNameA, workspaceNameB)
+				expOutput := fmt.Sprintf("\r\nWorkspace Name                                                                                              Workspace Path                                                                                          \r\n-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n\rtestA                                                                                                       %[1]s/%[2]s\n\rtestB                                                                                                       %[1]s/%[3]s\n", basePath, workspaceNameA, workspaceNameB)
 				assert.Equal(t, expOutput, actOutput)
 
 				return
@@ -1086,7 +1086,7 @@ func TestMatchStatementToHelp(t *testing.T) {
 		},
 		"error help command": {
 			statement: "help something",
-			expOutput: "",
+			expOutput: "\n\rYou need to specify a valid command, here is a list of possible commands:\n\r- ls\n\r- ls ws\n\r- create workspace\n\r- delete workspace\n\r- create node\n\r- delete node\n\r- create md\n\r- delete md\n\r- edit\n\r- goto\n\r- goback\n\r- open\n\r- version",
 		},
 	}
 

--- a/internal/commands/command_test.go
+++ b/internal/commands/command_test.go
@@ -1057,10 +1057,8 @@ func TestMatchStatementToListWorkspaces(t *testing.T) {
 			})
 			assert.NoError(t, err)
 			if tc.want {
-				basePath, err := utility.ExpandRelativePaths("./")
-				assert.NoError(t, err)
-				workspaceNameA := tc.workspacePaths[0][2:]
-				workspaceNameB := tc.workspacePaths[1][2:]
+				workspaceNameA := workspaceNodeA.Name
+				workspaceNameB := workspaceNodeB.Name
 				maximumLength := 2 * len("Workspace Name")
 				if len(workspaceNameA) > maximumLength {
 					maximumLength = len(workspaceNameA)
@@ -1075,7 +1073,8 @@ func TestMatchStatementToListWorkspaces(t *testing.T) {
 					maximumLength = len(workspacePathB)
 				}
 				totalWidth := 2*(maximumLength) + 1
-				expOutput := fmt.Sprintf("\r\nWorkspace Name                                                                                              Workspace Path                                                                                          \r\n%[4]s\n\rtestA                                                                                                       %[1]s/%[2]s\n\rtestB                                                                                                       %[1]s/%[3]s\n", basePath, workspaceNameA, workspaceNameB, strings.Repeat("-", totalWidth))
+
+				expOutput := fmt.Sprintf(fmt.Sprintf("\r\n%%-%[1]d.%[1]ds    %%-%[1]d.%[1]ds", maximumLength), "Workspace Name", "Workspace Path") + fmt.Sprintf("\r\n%s\n", strings.Repeat("-", totalWidth)) + fmt.Sprintf(fmt.Sprintf("\r%%-%[1]d.%[1]ds    %%-%[1]d.%[1]ds\n", maximumLength), workspaceNameA, workspacePathA) + fmt.Sprintf(fmt.Sprintf("\r%%-%[1]d.%[1]ds    %%-%[1]d.%[1]ds\n", maximumLength), workspaceNameB, workspacePathB)
 				assert.Equal(t, expOutput, actOutput)
 
 				return

--- a/internal/commands/help.go
+++ b/internal/commands/help.go
@@ -5,6 +5,24 @@ import (
 	"regexp"
 )
 
+var (
+	commands = []string{
+		"ls",
+		"ls ws",
+		"create workspace",
+		"delete workspace",
+		"create node",
+		"delete node",
+		"create md",
+		"delete md",
+		"edit",
+		"goto",
+		"goback",
+		"open",
+		"version",
+	}
+)
+
 type HelpStrategy struct {
 	statement string
 }
@@ -12,6 +30,13 @@ type HelpStrategy struct {
 func (hs *HelpStrategy) Run() error {
 	helpRegex := regexp.MustCompile("^help (?P<name>[[:alpha:]]+(?: [[:alpha:]]+)*)")
 	matches := helpRegex.FindStringSubmatch(hs.statement)
+	if len(matches) == 0 {
+		fmt.Print("\n\rYou need to specify a valid command, here is a list of possible commands:")
+		for _, command := range commands {
+			fmt.Printf("\n\r- %s", command)
+		}
+		return nil
+	}
 	names := helpRegex.SubexpNames()
 	namedGroups := make(map[string]string)
 	for i, name := range names {
@@ -57,6 +82,10 @@ func (hs *HelpStrategy) Run() error {
 		command = "\n\rCommand: delete md <markdownFileName>"
 		description = "\n\rDescription: delete md lets you delete the specified markdown file. Specify only the name, so without the file extension."
 		example = "\n\rExample Usage: delete md example"
+	case "edit":
+		command = "\n\rCommand: edit <markdownFileName>"
+		description = "\n\rDescription: edit md will open the specified markdown file in vim."
+		example = "\n\rExample usage: edit example"
 	case "goto":
 		command = "\n\rCommand: goto <nodeName>"
 		description = "\n\rDescription: goto will let you change the node, specify the name of the node that is a direct child of the node that you are on."
@@ -73,8 +102,13 @@ func (hs *HelpStrategy) Run() error {
 		command = "\n\rCommand: version"
 		description = "\n\rDescription: version will print notewolfy's version."
 		example = "\n\rExample Usage: version"
+	default:
+		fmt.Print("\n\rYou need to specify a valid command, here is a list of possible commands:")
+		for _, command := range commands {
+			fmt.Printf("\n\r- %s", command)
+		}
 	}
-	fmt.Printf(command + description + example)
+	fmt.Printf("%s%s%s", command, description, example)
 
 	return nil
 }

--- a/internal/console/app.go
+++ b/internal/console/app.go
@@ -1,8 +1,6 @@
 package console
 
 import (
-	"context"
-
 	"github.com/RaphSku/cyclecmd"
 	"github.com/RaphSku/notewolfy/cmd/version"
 )
@@ -16,7 +14,7 @@ func getEventHistory() *cyclecmd.EventHistory {
 	return eventHistory
 }
 
-func StartConsoleApplication(ctx context.Context) {
+func StartConsoleApplication() {
 	defaultEventInformation := cyclecmd.EventInformation{
 		EventName: "Default",
 		Event:     &DefaultEvent{},
@@ -50,7 +48,6 @@ func StartConsoleApplication(ctx context.Context) {
 	eventHistory := getEventHistory()
 
 	consoleApp := cyclecmd.NewConsoleApp(
-		context.Background(),
 		"notewolfy",
 		version.VERSION,
 		"Creating organized notes is just easy with notewolfy",

--- a/internal/structure/metadata.go
+++ b/internal/structure/metadata.go
@@ -157,7 +157,7 @@ func (mmf *MetadataNoteWolfyFileHandle) DeleteMarkdown(markdownName string) erro
 }
 
 func (mmf *MetadataNoteWolfyFileHandle) ListWorkspaces() {
-	longestStringLength := len("Workspace Name")
+	longestStringLength := 2 * len("Workspace Name")
 	for _, workspace := range mmf.Workspaces {
 		workspaceNameLength := len(workspace.Name)
 		if workspaceNameLength > longestStringLength {
@@ -169,11 +169,11 @@ func (mmf *MetadataNoteWolfyFileHandle) ListWorkspaces() {
 		}
 	}
 
-	fmt.Printf(fmt.Sprintf("\r\n%%-%[1]d.%[1]ds%%-%[1]d.%[1]ds", longestStringLength), "Workspace Name", "Workspace Path")
+	fmt.Printf(fmt.Sprintf("\r\n%%-%[1]d.%[1]ds    %%-%[1]d.%[1]ds", longestStringLength), "Workspace Name", "Workspace Path")
 	totalWidth := 2*longestStringLength + 1
 	fmt.Printf("\r\n%s\n", strings.Repeat("-", totalWidth))
 	for _, workspace := range mmf.Workspaces {
-		fmt.Printf(fmt.Sprintf("\r%%-%[1]d.%[1]ds%%-%[1]d.%[1]ds\n", longestStringLength), workspace.Name, workspace.Path)
+		fmt.Printf(fmt.Sprintf("\r%%-%[1]d.%[1]ds    %%-%[1]d.%[1]ds\n", longestStringLength), workspace.Name, workspace.Path)
 	}
 }
 

--- a/internal/structure/metadata_test.go
+++ b/internal/structure/metadata_test.go
@@ -403,7 +403,7 @@ func TestListWorkspaces(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	expOutput := "\r\nWorkspace NameWorkspace Path\r\n-----------------------------\n\rA             ./tmp/A       \n\rB             ./tmp/B       \n"
+	expOutput := "\r\nWorkspace Name                  Workspace Path              \r\n---------------------------------------------------------\n\rA                               ./tmp/A                     \n\rB                               ./tmp/B                     \n"
 	assert.Equal(t, expOutput, actOutput)
 }
 

--- a/main.go
+++ b/main.go
@@ -1,25 +1,10 @@
 package main
 
 import (
-	"context"
-	"os"
-
 	"github.com/RaphSku/notewolfy/cmd"
-	"github.com/RaphSku/notewolfy/internal/logging"
-	"go.uber.org/zap"
 )
 
 func main() {
-	// if debugLevel = 1, then debug logs are shown to os.Stdout, otherwise no logs will be printed
-	debugLevel := os.Getenv("NOTEWOLFY_DEBUG")
-	var logger *zap.Logger
-	if debugLevel == "1" {
-		logger = logging.SetupZapLogger(true)
-	} else {
-		logger = logging.SetupZapLogger(false)
-	}
-
-	cli := cmd.NewCLI(context.Background(), logger)
-	cli.AddSubCommands()
-	cli.Execute()
+	cli := cmd.NewCLI()
+	cli.Run()
 }


### PR DESCRIPTION
[ENHANCEMENTS]:
When the user uses commands with a wrong naming pattern, more helpful messages are displayed, sometimes even nothing was being displayed as feedback. When using help and you do not specify any command, you will now see a list of commands that exist.

[BUGFIXES]:
The help command was missing the edit command and also help could crash the application when using a non-existent command. Also, vi was opened when using edit but it should be vim. When using arrow keys, they could exit the application since escape sequences were not handled properly.